### PR TITLE
Fix typos

### DIFF
--- a/build-source/dev.Dockerfile
+++ b/build-source/dev.Dockerfile
@@ -54,7 +54,7 @@ RUN pip install -U "huggingface_hub[cli]"
 
 # Disable debug, info, and warning tensorflow logs
 ENV TF_CPP_MIN_LOG_LEVEL=3
-# By default use cpu as the backend for JAX, we will explicitely load data on gpus/tpus as needed.
+# By default use cpu as the backend for JAX, we will explicitly load data on gpus/tpus as needed.
 # ENV JAX_PLATFORM_NAME="cpu"
 
 # Installing the lddt and tm scores

--- a/scripts/lm/generation_utils.py
+++ b/scripts/lm/generation_utils.py
@@ -71,7 +71,7 @@ def update_top_k_sampling(
         This function implements top_k sampling:
         1. it first select the k highest logits values and indices
         2. it then samples randomly the selected indices using the previously
-            estimated logits (optionnaly rescaled by temperature)
+            estimated logits (optionally rescaled by temperature)
 
     :param tokens_ids:
     :param time_step:

--- a/structure_tokenizer/data/preprocessing.py
+++ b/structure_tokenizer/data/preprocessing.py
@@ -68,7 +68,7 @@ def preprocess_sample(
     # Building protein graph
     atom37_coords = sample.atom37_positions
 
-    # carefull, this can be tricky !
+    # carefully, this can be tricky !
     atom37_mask = sample.atom37_gt_exists & sample.atom37_atom_exists
     missing_coords_residue_mask = sample.get_missing_backbone_coords_mask()
 

--- a/structure_tokenizer/data/protein_structure_sample.py
+++ b/structure_tokenizer/data/protein_structure_sample.py
@@ -151,7 +151,7 @@ class ProteinStructureSample(NamedTuple):
             * self.atom37_gt_exists[..., atom37_atom_to_idx["CA"]].astype(np.float32)
             * self.atom37_gt_exists[..., atom37_atom_to_idx["C"]].astype(np.float32)
         )
-        # rigid groupd features
+        # rigid grouped features
         rigidgroups_features = all_atom.atom37_to_frames(
             np.argmax(self.aatype, axis=-1),
             self.atom37_positions,

--- a/structure_tokenizer/model/model.py
+++ b/structure_tokenizer/model/model.py
@@ -250,7 +250,7 @@ class Vq3D(hk.Module):
         #
         quantized_emb["quantize_post_proj"] = quantized_proj
 
-        # Strucutre module
+        # Structure module
         representation = {"single": s_i, "pair": z_ij}
         decoded_structure = self.structure_module(
             representation, batch.features, nodes_mask
@@ -576,7 +576,7 @@ class ForwardVQ3D(hk.Module):
     """Autoencoder module of Vq3D model"""
 
     def __init__(self, config, global_config):
-        """Class to peform Vq3D foward pass
+        """Class to perform Vq3D forward pass
 
         Args:
             config (BioClipConfig): model hyperparameters
@@ -611,7 +611,7 @@ class ForwardVQ3D(hk.Module):
             batch_data (BatchDataVQ3D): batch data
 
         Returns:
-            decoded_structure: reconstructed strucutre
+            decoded_structure: reconstructed structure
             seq_emb: quantized representation
             quantized_emb: aux embedding and metrics dict
         """

--- a/structure_tokenizer/model/modules.py
+++ b/structure_tokenizer/model/modules.py
@@ -43,7 +43,7 @@ StraightThroughQuantized: TypeAlias = jnp.ndarray
 
 
 class GraphNeuralNetwork(hk.Module):
-    """Independent-Equivariant Graph Matching Newtork"""
+    """Independent-Equivariant Graph Matching Network"""
 
     def __init__(
         self,
@@ -383,7 +383,7 @@ class Attention(hk.Module):
 
 
 class CrossAttention(hk.Module):
-    """Single rows cross-attention for re sampling seq. lenght."""
+    """Single rows cross-attention for re sampling seq. length."""
 
     def __init__(self, config, global_config, name="resampling_cross_attention"):
         super().__init__(name=name)
@@ -664,7 +664,7 @@ class PairwiseRepresentation(hk.Module):
         obtain two vectors (N_residues, input_dim) from a single vector
         (N_residues, input_dim)
 
-        Then outter product them --> (N_residues, N_residues, input_dim)
+        Then outer product them --> (N_residues, N_residues, input_dim)
 
         and scale --> (N_residues, N_residues, outdim)
 
@@ -697,7 +697,7 @@ class PairwiseRepresentation(hk.Module):
             w_init=self.w_init,
         )(x)
 
-        # now perform outter product
+        # now perform outer product
         init_pairwise_representation = jnp.einsum(
             "...nd, ...kd -> ...nkd ", left_proj, right_proj
         )

--- a/structure_tokenizer/model/positional_encoding_layer.py
+++ b/structure_tokenizer/model/positional_encoding_layer.py
@@ -25,7 +25,7 @@ from structure_tokenizer.types import EdgeFeatures, NodeFeatures
 
 
 class PositionalEncodingLayer(hk.Module):
-    """Independent-Equivariant Graph Matching Newtork"""
+    """Independent-Equivariant Graph Matching Network"""
 
     def __init__(self, positional_encoding_dimension: int):
         """Initializes a Positional Encoding Layer

--- a/structure_tokenizer/model/quantize.py
+++ b/structure_tokenizer/model/quantize.py
@@ -89,7 +89,7 @@ class FiniteScalarCodebook(hk.Module):
         super().__init__(name)
         self.config = config
 
-        # definine the finite grid (aka implicit codebook)
+        # define the finite grid (aka implicit codebook)
         self.levels = config.levels
         self.levels_jnp = jnp.asarray(config.levels)
         self.basis = jnp.concatenate(
@@ -120,7 +120,7 @@ class FiniteScalarCodebook(hk.Module):
         return (zhat * self.basis).sum(axis=-1).astype(jnp.uint32)
 
     def indexes_to_codes(self, indices):
-        """Inverse of ‘indexes_to_codes‘, optionnaly not renorming"""
+        """Inverse of ‘indexes_to_codes‘, optionally not renorming"""
 
         basis = jnp.concatenate(
             (jnp.ones((1,)), jnp.cumprod(self.levels_jnp[:-1]))

--- a/structure_tokenizer/utils/protein_utils.py
+++ b/structure_tokenizer/utils/protein_utils.py
@@ -421,7 +421,7 @@ def compute_nearest_neighbors_graph(
         "ijk,nk->inj", basis_matrices, protein_v_i_feat
     )  # orientation edges features 1
     s_ij = np.concatenate([p_ij, q_ij, k_ij, t_ij], axis=-1)
-    # Get edges features for valid (send, reveiver) pairs
+    # Get edges features for valid (send, receiver) pairs
     protein_edge_feat_ori_list = [
         s_ij[receivers[i], senders[i]] for i in range(len(protein_dist_list))
     ]

--- a/structure_tokenizer/utils/utils.py
+++ b/structure_tokenizer/utils/utils.py
@@ -30,7 +30,7 @@ import numpy as np
 def convert_to_ml_dict(dct: Union[DictConfig, Any]) -> Union[ConfigDict, Any]:
     """
     This function converts the DictConfig returned by Hydra
-    into a ConfigDict. The recusion allows to convert
+    into a ConfigDict. The recursion allows to convert
     all the nested DictConfig elements of the config. The recursion stops
     once the reached element is not a DictConfig.
     """


### PR DESCRIPTION
This PR fixes a few typos thet were found by running [`codespell`](https://github.com/codespell-project/codespell) on the repository

```
$ codespell . --skip="*.pdb" -L meu,ser,nd                       
./scripts/lm/generation_utils.py:74: optionnaly ==> optionally
./structure_tokenizer/model/model.py:253: Strucutre ==> Structure
./structure_tokenizer/model/model.py:579: peform ==> perform
./structure_tokenizer/model/model.py:579: foward ==> forward
./structure_tokenizer/model/model.py:614: strucutre ==> structure
./structure_tokenizer/model/modules.py:46: Newtork ==> Network
./structure_tokenizer/model/modules.py:386: lenght ==> length
./structure_tokenizer/model/modules.py:667: outter ==> outer
./structure_tokenizer/model/modules.py:700: outter ==> outer
./structure_tokenizer/model/positional_encoding_layer.py:28: Newtork ==> Network
./structure_tokenizer/model/quantize.py:92: definine ==> define, definite
./structure_tokenizer/model/quantize.py:123: optionnaly ==> optionally
./structure_tokenizer/data/preprocessing.py:71: carefull ==> careful, carefully
./structure_tokenizer/data/protein_structure_sample.py:154: groupd ==> grouped
./structure_tokenizer/utils/protein_utils.py:424: reveiver ==> receiver, reviewer, reviver
./structure_tokenizer/utils/utils.py:33: recusion ==> recursion, reclusion
./build-source/dev.Dockerfile:57: explicitely ==> explicitly
```